### PR TITLE
Include this to avoid ReferenceError

### DIFF
--- a/source/ReactInput.js
+++ b/source/ReactInput.js
@@ -183,7 +183,7 @@ export default class ReactInput extends React.Component
 				target:
 				{
 					...event.target,
-					value: _parse(getInputElement().value, undefined, parse).value
+					value: _parse(this.getInputElement().value, undefined, parse).value
 				}
 			}
 


### PR DESCRIPTION
`getInputElement` is not defined anywhere else than on `this`, and we had to apply this fix locally in order to get the new version of this library to work. We might very well have misunderstood something, but as far as I can tell, there is a bug in the library now, and this should be included to fix it.